### PR TITLE
Change the action auto commit author

### DIFF
--- a/update-asdf-and-dockerfile/action.yml
+++ b/update-asdf-and-dockerfile/action.yml
@@ -95,3 +95,4 @@ runs:
         body: 'See release notes in: ${{ env.RELEASE_NOTES }}'
         delete-branch: true
         labels: 'update,enhancement'
+        author: 'GitHub <noreply@github.com>'


### PR DESCRIPTION
Current creates all commits that the action produces as the person who created the action. This makes little sense as when the action runs, the original creator has little to do with all of the subsequent PR's the action creates and may create confusion.

Changed the author to `GitHub <noreply@github.com>` from default (action creator). See docs for info:
https://github.com/peter-evans/create-pull-request#action-inputs