### PR TITLE
Update npm & node versions in package.json engines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/update-asdf-and-dockerfile/action.yml
+++ b/update-asdf-and-dockerfile/action.yml
@@ -82,6 +82,15 @@ runs:
       shell: bash
       run: |
         test -n "${{ inputs.docker_image }}" && test -f Dockerfile && sed -i "s/^FROM ${{ inputs.docker_image }}:${{ env.CURRENT_VERSION }}/FROM ${{ inputs.docker_image }}:${{ env.LATEST_VERSION }}/" Dockerfile
+    - name: Update latest versions to package.json engines if it exists
+      shell: bash
+      run: |
+        test -f package.json && \
+        sudo apt-get update && \
+        sudo apt-get install jq && \
+        asdf install && \
+        cat package.json | jq ".engines.node |= \"^$(node --version | tr -d v)\"" | jq ".engines.npm |= \"^$(npm --version)\"" > updated-package.json && \
+        mv updated-package.json package.json
 
     # This is using the version 4.2.3
     # Reference the repository with SHA for security


### PR DESCRIPTION
As suggested by @katalaakkonen it would be great that the npm version will be locked in `package.json` and that when asdf auto updater will recommend updates in `.tool-versions` it would also touch the engines section of `package.json`

This PR tries to do exactly that.

Also it ignore .DS_Store files in git

