### PR TITLE
Only run the package.json engines updates for nodejs plugin and not python

### DIFF
--- a/update-asdf-and-dockerfile/action.yml
+++ b/update-asdf-and-dockerfile/action.yml
@@ -88,17 +88,21 @@ runs:
       shell: bash
       run: |
         test -f package.json && \
+        echo "package.json engines before update:" && \
+        jq ".engines" package.json && \
         asdf install nodejs ${{ env.LATEST_VERSION }} && \
         asdf global nodejs ${{ env.LATEST_VERSION }} && \
         cat package.json | jq ".engines.node |= \"^$(node --version | tr -d v)\"" | jq ".engines.npm |= \"^$(npm --version)\"" > updated-package.json && \
-        mv updated-package.json package.json
+        mv updated-package.json package.json && \
+        echo "package.json engines after update:" && \
+        jq ".engines" package.json
 
     # This is using the version 4.2.3
     # Reference the repository with SHA for security
     # Source: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
     - uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04
       with:
-        add-paths: '.tool-versions,Dockerfile'
+        add-paths: '.tool-versions,Dockerfile,package.json'
         commit-message: 'Update ${{ inputs.plugin }} from ${{ env.CURRENT_VERSION }} to ${{ env.LATEST_VERSION }}'
         title: 'Update ${{ inputs.plugin }} from ${{ env.CURRENT_VERSION }} to ${{ env.LATEST_VERSION }}'
         branch: 'update/${{ inputs.plugin }}/${{ env.LATEST_VERSION }}'

--- a/update-asdf-and-dockerfile/action.yml
+++ b/update-asdf-and-dockerfile/action.yml
@@ -88,8 +88,6 @@ runs:
       shell: bash
       run: |
         test -f package.json && \
-        sudo apt-get update && \
-        sudo apt-get install jq && \
         asdf install nodejs ${{ env.LATEST_VERSION }} && \
         asdf global nodejs ${{ env.LATEST_VERSION }} && \
         cat package.json | jq ".engines.node |= \"^$(node --version | tr -d v)\"" | jq ".engines.npm |= \"^$(npm --version)\"" > updated-package.json && \

--- a/update-asdf-and-dockerfile/action.yml
+++ b/update-asdf-and-dockerfile/action.yml
@@ -82,13 +82,16 @@ runs:
       shell: bash
       run: |
         test -n "${{ inputs.docker_image }}" && test -f Dockerfile && sed -i "s/^FROM ${{ inputs.docker_image }}:${{ env.CURRENT_VERSION }}/FROM ${{ inputs.docker_image }}:${{ env.LATEST_VERSION }}/" Dockerfile
+    # We need to actually install nodejs to see the bundled npm version of the new nodejs
     - name: Update latest versions to package.json engines if it exists
+      if: ${{ inputs.plugin == 'nodejs' }}
       shell: bash
       run: |
         test -f package.json && \
         sudo apt-get update && \
         sudo apt-get install jq && \
-        asdf install && \
+        asdf install nodejs ${{ env.LATEST_VERSION }} && \
+        asdf global nodejs ${{ env.LATEST_VERSION }} && \
         cat package.json | jq ".engines.node |= \"^$(node --version | tr -d v)\"" | jq ".engines.npm |= \"^$(npm --version)\"" > updated-package.json && \
         mv updated-package.json package.json
 


### PR DESCRIPTION
Earlier version also updated the package.json engines even when it's updating python version 😓

This should limit this action to only trigger when nodejs is getting a update.

Also `jq` is installed there already according to the logs so i removed this step from the installation:
```
Hit:1 http://azure.archive.ubuntu.com/ubuntu jammy InRelease
Get:2 http://azure.archive.ubuntu.com/ubuntu jammy-updates InRelease [119 kB]
...
Get:30 https://packages.microsoft.com/ubuntu/22.04/prod jammy/main arm64 Packages [13.6 kB]
Fetched 5427 kB in 1s (4489 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
jq is already the newest version (1.6-2.1ubuntu3).
```