### PR TITLE
add wildcard for package.json to not raise error if not existing

### DIFF
--- a/update-asdf-and-dockerfile/action.yml
+++ b/update-asdf-and-dockerfile/action.yml
@@ -106,7 +106,11 @@ runs:
     # Source: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
     - uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04
       with:
-        add-paths: '.tool-versions,Dockerfile,package.json,package-lock.json'
+        add-paths: |
+            .tool-versions
+            Dockerfile
+            '*package.json'
+            '*package-lock.json'
         commit-message: 'Update ${{ inputs.plugin }} from ${{ env.CURRENT_VERSION }} to ${{ env.LATEST_VERSION }}'
         title: 'Update ${{ inputs.plugin }} from ${{ env.CURRENT_VERSION }} to ${{ env.LATEST_VERSION }}'
         branch: 'update/${{ inputs.plugin }}/${{ env.LATEST_VERSION }}'


### PR DESCRIPTION
Use a the `'` and wildcard `*` in the add pathspec to match all pacakge.json files and not encounter  `pathspec 'xxx' did not match any files` kind of error

![image](https://github.com/swappiehq/github-actions/assets/9247857/f21a48b2-1285-410b-a7e6-f4cbaf563d6d)
