### PR TITLE
add package_json_prefix input

### DIFF
--- a/update-asdf-and-dockerfile/action.yml
+++ b/update-asdf-and-dockerfile/action.yml
@@ -21,6 +21,10 @@ inputs:
   release_notes:
     type: string
     required: true
+  package_json_prefix:
+    type: string
+    required: false
+    default: "."
 
 runs:
   using: "composite"
@@ -87,19 +91,19 @@ runs:
       if: ${{ inputs.plugin == 'nodejs' }}
       shell: bash
       run: |
-        test -f package.json && \
+        test -f {{ inputs.package_json_prefix }}/package.json && \
         echo "package.json engines before update:" && \
-        jq ".engines" package.json && \
+        jq ".engines" {{ inputs.package_json_prefix }}/package.json && \
         asdf install nodejs ${{ env.LATEST_VERSION }} && \
         asdf global nodejs ${{ env.LATEST_VERSION }} && \
-        cat package.json | jq ".engines.node |= \"^$(node --version | tr -d v)\"" | jq ".engines.npm |= \"^$(npm --version)\"" > updated-package.json && \
-        mv updated-package.json package.json && \
+        cat {{ inputs.package_json_prefix }}/package.json | jq ".engines.node |= \"^$(node --version | tr -d v)\"" | jq ".engines.npm |= \"^$(npm --version)\"" > updated-package.json && \
+        mv updated-package.json {{ inputs.package_json_prefix }}/package.json && \
         echo "package.json engines after update:" && \
-        jq ".engines" package.json
+        jq ".engines" {{ inputs.package_json_prefix }}/package.json
     - name: Run npm install to update package-lock.json
       if: ${{ inputs.plugin == 'nodejs' && env.CURRENT_VERSION != env.LATEST_VERSION }}
       shell: bash
-      run: npm install
+      run: npm --prefix {{ inputs.package_json_prefix }} install
 
     # This is using the version 4.2.3
     # Reference the repository with SHA for security

--- a/update-nodejs/action.yml
+++ b/update-nodejs/action.yml
@@ -10,6 +10,10 @@ inputs:
       - lts
       - minor # Semver minor updates from MAJOR.MINOR.PATCH
       - patch # Semver patch updates from MAJOR.MINOR.PATCH
+  package_json_prefix:
+    type: string
+    required: false
+    default: "."
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
As requested [here](https://swappie.slack.com/archives/C02K4Q1A6E8/p1684169005546109?thread_ts=1684141576.249229&cid=C02K4Q1A6E8) add a prefix option to be able to make the laakso NodeJs update works

Not sure how much of this could be replace by a wild card as in https://github.com/swappiehq/github-actions/pull/6 But i think for this case we would prefer to use the prefix input