### PR TITLE
Update npm & node versions in engines section of package.json without installing nodejs or npm packages

### DIFF
--- a/update-asdf-and-dockerfile/action.yml
+++ b/update-asdf-and-dockerfile/action.yml
@@ -83,24 +83,20 @@ runs:
       shell: bash
       run: |
         test -n "${{ inputs.docker_image }}" && test -f Dockerfile && sed -i "s/^FROM ${{ inputs.docker_image }}:${{ env.CURRENT_VERSION }}/FROM ${{ inputs.docker_image }}:${{ env.LATEST_VERSION }}/" Dockerfile
-    # We need to actually install nodejs to see the bundled npm version of the new nodejs
-    - name: Update latest versions to package.json engines if it exists
+    # This fetches the bundled NPM version from nodejs.org so that we don't need to install nodejs+npm packages here
+    - name: Update latest node/npm versions to package.json engines if it exists
       if: ${{ inputs.plugin == 'nodejs' && env.CURRENT_VERSION != env.LATEST_VERSION }}
       shell: bash
       run: |
-        test -f ${{ inputs.package_json_prefix }}/package.json && \
-        echo "package.json engines before update:" && \
-        jq ".engines" ${{ inputs.package_json_prefix }}/package.json && \
-        asdf install nodejs ${{ env.LATEST_VERSION }} && \
-        asdf global nodejs ${{ env.LATEST_VERSION }} && \
-        cat ${{ inputs.package_json_prefix }}/package.json | jq ".engines.node |= \"^$(node --version | tr -d v)\"" | jq ".engines.npm |= \"^$(npm --version)\"" > updated-package.json && \
-        mv updated-package.json ${{ inputs.package_json_prefix }}/package.json && \
-        echo "package.json engines after update:" && \
-        jq ".engines" ${{ inputs.package_json_prefix }}/package.json
-    - name: Run npm install to update package-lock.json
-      if: ${{ inputs.plugin == 'nodejs' && env.CURRENT_VERSION != env.LATEST_VERSION }}
-      shell: bash
-      run: npm --prefix ${{ inputs.package_json_prefix }} install
+        PACKAGE_JSON=${{ inputs.package_json_prefix }}/package.json
+        LOCK_JSON=${{ inputs.package_json_prefix }}/package-lock.json
+        test -f $PACKAGE_JSON && jq ".engines" $PACKAGE_JSON || { echo "Skipping update since package.json or engines don't exist"; exit 0; }
+        BUNDLED_NPM_VERSION=$(curl https://nodejs.org/dist/index.json | jq ".[] | select(.version == \"v${{ env.LATEST_VERSION }}\") | .npm" | head -n 1)
+        [[ "$BUNDLED_NPM_VERSION" =~ ^[.0-9]+$ ]] || { echo "Failed to fetch the new NPM version"; exit 1; }
+        jq ".engines.node = \"^${{ env.LATEST_VERSION }}\" | .engines.npm = \"^$BUNDLED_NPM_VERSION\"" $PACKAGE_JSON > updated-package.json
+        jq ".packages.\"\".engines.node = \"^${{ env.LATEST_VERSION }}\" | .packages.\"\".engines.npm = \"^$BUNDLED_NPM_VERSION\"" $LOCK_JSON > updated-package-lock.json
+        mv updated-package.json $PACKAGE_JSON
+        mv updated-package-lock.json $LOCK_JSON
 
     # This is using the version 4.2.3
     # Reference the repository with SHA for security


### PR DESCRIPTION
This should make it a bit faster and cheaper