### PR TITLE
Fix LTS version upgrade related comparison typo

### DIFF
--- a/update-asdf-and-dockerfile/action.yml
+++ b/update-asdf-and-dockerfile/action.yml
@@ -59,7 +59,7 @@ runs:
         echo "LATEST_VERSION=${LATEST_VERSION}" >> $GITHUB_ENV
     # NodeJS has LTS versions
     - name: Get newest NodeJS LTS version
-      if: ${{ inputs.version == 'lts' && inputs.plugin = 'nodejs' }}
+      if: ${{ inputs.version == 'lts' && inputs.plugin == 'nodejs' }}
       shell: bash
       run: |
         LATEST_VERSION=$(asdf latest nodejs $(asdf nodejs resolve lts))


### PR DESCRIPTION
This fixes a typo I made earlier here and should fix the automatic updates.

I tried to check if I could prevent these errors in the future with validating with https://github.com/mpalmer/action-validator but it didn't spot this issue and only gave errors from the inputs of these files.

I guess it doesn't work properly with composite type actions 😞 

Tech-Support thread: https://swappie.slack.com/archives/C9ABB0CTF/p1686052859569789