### PR TITLE
Attempt at adding package files only on node upgrades

### DIFF
--- a/update-asdf-and-dockerfile/action.yml
+++ b/update-asdf-and-dockerfile/action.yml
@@ -108,11 +108,7 @@ runs:
     # Here we use a wild card for the package.json files to avoid "pathspec 'xxx' did not match any files" errors as package.json files may not exist or be in subdirectories
     - uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04
       with:
-        add-paths: |
-            .tool-versions
-            Dockerfile
-            *package.json
-            *package-lock.json
+        add-paths: .tool-versions, Dockerfile${{inputs.plugin == 'nodejs' && ', *package.json, *package-lock.json' || '' }}
         commit-message: 'Update ${{ inputs.plugin }} from ${{ env.CURRENT_VERSION }} to ${{ env.LATEST_VERSION }}'
         title: 'Update ${{ inputs.plugin }} from ${{ env.CURRENT_VERSION }} to ${{ env.LATEST_VERSION }}'
         branch: 'update/${{ inputs.plugin }}/${{ env.LATEST_VERSION }}'


### PR DESCRIPTION
Git add in git checkout action fails if we don't have the files present at all, which causes issues as it seeks package.json which we dont have in python projects. This makes those files conditional on if we're upgrading node.