### PR TITLE
Update new python version automatically into poetry config pyproject.toml file too

### DIFF
--- a/update-asdf-and-dockerfile/action.yml
+++ b/update-asdf-and-dockerfile/action.yml
@@ -97,6 +97,18 @@ runs:
         jq ".packages.\"\".engines.node = \"^${{ env.LATEST_VERSION }}\" | .packages.\"\".engines.npm = \"^$BUNDLED_NPM_VERSION\"" $LOCK_JSON > updated-package-lock.json
         mv updated-package.json $PACKAGE_JSON
         mv updated-package-lock.json $LOCK_JSON
+    
+    - name: Update latest python version to pyproject.toml if it exists
+      if: ${{ inputs.plugin == 'python' && env.CURRENT_VERSION != env.LATEST_VERSION }}
+      shell: bash
+      run: |
+        test -f pyproject.toml && \
+        sed -i "s/^python =.*/python = \"^${{ env.LATEST_VERSION }}\"/" pyproject.toml && \
+        asdf plugin-add python && \
+        asdf plugin-add poetry && \
+        asdf install python && \
+        asdf install poetry && \
+        poetry lock --no-update
 
     # This is using the version 4.2.3
     # Reference the repository with SHA for security


### PR DESCRIPTION
Inspired by what Kata suggested earlier for the node `package.json` engine updates.

I noticed that in few projects we have done this manually but forgotten to do it sometimes. I will share links to those PRs in our internal slack if asked separately since this is public repository.

This should help us to keep the python version between asdf and poetry in sync.