### PR TITLE
fix pyproject toml upgrades

### DIFF
--- a/update-asdf-and-dockerfile/action.yml
+++ b/update-asdf-and-dockerfile/action.yml
@@ -98,14 +98,17 @@ runs:
         mv updated-package.json $PACKAGE_JSON
         mv updated-package-lock.json $LOCK_JSON
     
-    # The earlier 'ASDF Setup plugins' step already installs all plugins and related languages
-    # Because of this we can just directly use poetry/python/node/npm here
+    # The earlier 'ASDF Setup plugins' step already installs all used plugins
+    # We only need python/poetry here so cherry-pick install them from all possible things
+    # from .tool-versions file
     - name: Update latest python version to pyproject.toml if it exists
       if: ${{ inputs.plugin == 'python' && env.CURRENT_VERSION != env.LATEST_VERSION }}
       shell: bash
       run: |
         test -f pyproject.toml && \
         sed -i "s/^python =.*/python = \"^${{ env.LATEST_VERSION }}\"/" pyproject.toml && \
+        asdf install python && \
+        asdf install poetry && \
         poetry lock --no-update
 
     # This is using the version 4.2.3


### PR DESCRIPTION
Continuing the saga from #17 & #18.

asdf plugins were installed automatically but the python & poetry still need to be installed manually 🤕

<img width="940" alt="Screenshot 2023-06-30 at 12 19 25" src="https://github.com/swappiehq/github-actions/assets/5691777/bda90404-1f45-43be-8623-18c98f13f718">
