### PR TITLE
Add poetry files to the created PRs created by python action and refactor extra files into input parameter

### DIFF
--- a/update-asdf-and-dockerfile/action.yml
+++ b/update-asdf-and-dockerfile/action.yml
@@ -25,6 +25,10 @@ inputs:
     type: string
     required: false
     default: "."
+  add_extra_files_to_pr:
+    type: string
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -117,7 +121,7 @@ runs:
     # Here we use a wild card for the package.json files to avoid "pathspec 'xxx' did not match any files" errors as package.json files may not exist or be in subdirectories
     - uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04
       with:
-        add-paths: .tool-versions, Dockerfile${{inputs.plugin == 'nodejs' && ', *package.json, *package-lock.json' || '' }}
+        add-paths: .tool-versions, Dockerfile${{inputs.add_extra_files_to_pr != '' && format(', {0}', inputs.add_extra_files_to_pr) || '' }}
         commit-message: 'Update ${{ inputs.plugin }} from ${{ env.CURRENT_VERSION }} to ${{ env.LATEST_VERSION }}'
         title: 'Update ${{ inputs.plugin }} from ${{ env.CURRENT_VERSION }} to ${{ env.LATEST_VERSION }}'
         branch: 'update/${{ inputs.plugin }}/${{ env.LATEST_VERSION }}'

--- a/update-nodejs/action.yml
+++ b/update-nodejs/action.yml
@@ -27,3 +27,5 @@ runs:
         version: '${{ inputs.version }}'
         package_json_prefix: '${{ inputs.package_json_prefix }}'
         release_notes: "https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V$MAJOR_VERSION.md#$LATEST_VERSION"
+        # Github actions doesn't support array items so we just concatenate these
+        add_extra_files_to_pr: '*package.json, *package-lock.json'

--- a/update-python/action.yml
+++ b/update-python/action.yml
@@ -21,3 +21,5 @@ runs:
         docker_image: python
         version: '${{ inputs.version }}'
         release_notes: "https://docs.python.org/$MINOR_VERSION/whatsnew/changelog.html#python-$LATEST_VERSION_WITH_DASHES-final"
+        # Github actions doesn't support array items so we just concatenate these
+        add_extra_files_to_pr: '*pyproject.toml, *poetry.lock'


### PR DESCRIPTION
One last step in saga started in #17, #18, #19 is to actually commit the files that it creates as part of the PR 😅

I used the [format](https://docs.github.com/en/actions/learn-github-actions/expressions#example-of-format) function provided by github to allow the extra parameter to be empty in future plugins.