### PR TITLE
Add Pull Request template to warn that this is a publicly available repository

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Description
+<!--
+- THIS REPO IS PUBLIC AND OPEN FOR ALL INTERNET
+- This was done so that we don't need to manage authentication for this repo
+- And because this repo does not make our beer taste better and it can be public
+- So don't share internal links into this repo
+-->
+
+_(Description here)_
+
+
+## Checklist
+- [ ] After merging this I have tested this by manually triggering the action in one of the internal projects


### PR DESCRIPTION
I don't think it's too dangerous but we probably don't want to link internal repositories into this repository.

Github doesn't really make it crystal clear which repos are private and which are public.