### PR TITLE
Don't try to fetch NPM version with curl but actually install the latest nodejs with bundled npm version

### DIFF
--- a/update-asdf-and-dockerfile/action.yml
+++ b/update-asdf-and-dockerfile/action.yml
@@ -95,7 +95,8 @@ runs:
         PACKAGE_JSON=${{ inputs.package_json_prefix }}/package.json
         LOCK_JSON=${{ inputs.package_json_prefix }}/package-lock.json
         test -f $PACKAGE_JSON && jq ".engines" $PACKAGE_JSON || { echo "Skipping update since package.json or engines don't exist"; exit 0; }
-        BUNDLED_NPM_VERSION=$(curl https://nodejs.org/dist/index.json | jq ".[] | select(.version == \"v${{ env.LATEST_VERSION }}\") | .npm" | head -n 1)
+        asdf install nodejs ${{ env.LATEST_VERSION }}
+        BUNDLED_NPM_VERSION=$(asdf exec npm --version)
         [[ "$BUNDLED_NPM_VERSION" =~ ^[.0-9]+$ ]] || { echo "Failed to fetch the new NPM version"; exit 1; }
         jq ".engines.node = \"^${{ env.LATEST_VERSION }}\" | .engines.npm = \"^$BUNDLED_NPM_VERSION\"" $PACKAGE_JSON > updated-package.json
         jq ".packages.\"\".engines.node = \"^${{ env.LATEST_VERSION }}\" | .packages.\"\".engines.npm = \"^$BUNDLED_NPM_VERSION\"" $LOCK_JSON > updated-package-lock.json

--- a/update-asdf-and-dockerfile/action.yml
+++ b/update-asdf-and-dockerfile/action.yml
@@ -97,7 +97,7 @@ runs:
         test -f $PACKAGE_JSON && jq ".engines" $PACKAGE_JSON || { echo "Skipping update since package.json or engines don't exist"; exit 0; }
         asdf install nodejs ${{ env.LATEST_VERSION }}
         BUNDLED_NPM_VERSION=$(asdf exec npm --version)
-        [[ "$BUNDLED_NPM_VERSION" =~ ^[.0-9]+$ ]] || { echo "Failed to fetch the new NPM version"; exit 1; }
+        [[ "$BUNDLED_NPM_VERSION" =~ ^[.0-9]+$ ]] || { echo "Failed to fetch the new NPM version. Got malformed version: $BUNDLED_NPM_VERSION"; exit 1; }
         jq ".engines.node = \"^${{ env.LATEST_VERSION }}\" | .engines.npm = \"^$BUNDLED_NPM_VERSION\"" $PACKAGE_JSON > updated-package.json
         jq ".packages.\"\".engines.node = \"^${{ env.LATEST_VERSION }}\" | .packages.\"\".engines.npm = \"^$BUNDLED_NPM_VERSION\"" $LOCK_JSON > updated-package-lock.json
         mv updated-package.json $PACKAGE_JSON


### PR DESCRIPTION
## Description
@katalaakkonen & @viktor-ku noticed that the latest node updates had been broken for a moment with the message `Failed to fetch the new NPM version`

This will make it a bit slower but hopefully more robust 🤞 

## Checklist
- [ ] After merging this I have tested this by manually triggering the action in one of the internal projects