### PR TITLE
Mimick same labels as what Dependabot is already using in the same repositories

### DIFF
--- a/update-asdf-and-dockerfile/action.yml
+++ b/update-asdf-and-dockerfile/action.yml
@@ -136,5 +136,5 @@ runs:
         branch: 'update/${{ inputs.plugin }}/${{ env.LATEST_VERSION }}'
         body: 'See release notes in: ${{ env.RELEASE_NOTES }}'
         delete-branch: true
-        labels: 'update,enhancement'
+        labels: 'dependencies,${{ inputs.github_pullrequest_labels }}'
         author: 'GitHub <noreply@github.com>'

--- a/update-asdf-and-dockerfile/action.yml
+++ b/update-asdf-and-dockerfile/action.yml
@@ -21,6 +21,9 @@ inputs:
   release_notes:
     type: string
     required: true
+  github_pullrequest_extra_labels:
+    type: string
+    required: true
   package_json_prefix:
     type: string
     required: false
@@ -136,5 +139,5 @@ runs:
         branch: 'update/${{ inputs.plugin }}/${{ env.LATEST_VERSION }}'
         body: 'See release notes in: ${{ env.RELEASE_NOTES }}'
         delete-branch: true
-        labels: 'dependencies,${{ inputs.github_pullrequest_labels }}'
+        labels: 'dependencies,${{ inputs.github_pullrequest_extra_labels }}'
         author: 'GitHub <noreply@github.com>'

--- a/update-nodejs/action.yml
+++ b/update-nodejs/action.yml
@@ -29,3 +29,5 @@ runs:
         release_notes: "https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V$MAJOR_VERSION.md#$LATEST_VERSION"
         # Github actions doesn't support array items so we just concatenate these
         add_extra_files_to_pr: '*package.json, *package-lock.json'
+        # Use similiar PR labels as Dependabot is using
+        github_pullrequest_labels: 'javascript'

--- a/update-poetry/action.yml
+++ b/update-poetry/action.yml
@@ -20,3 +20,5 @@ runs:
         plugin: poetry
         version: '${{ inputs.version }}'
         release_notes: "https://github.com/python-poetry/poetry/releases/tag/$LATEST_VERSION"
+        # Use similiar PR labels as Dependabot is using
+        github_pullrequest_label: 'python,poetry'

--- a/update-python/action.yml
+++ b/update-python/action.yml
@@ -19,7 +19,10 @@ runs:
       with:
         plugin: python
         docker_image: python
+        
         version: '${{ inputs.version }}'
         release_notes: "https://docs.python.org/$MINOR_VERSION/whatsnew/changelog.html#python-$LATEST_VERSION_WITH_DASHES-final"
         # Github actions doesn't support array items so we just concatenate these
         add_extra_files_to_pr: '*pyproject.toml, *poetry.lock'
+        # Use similiar PR labels as Dependabot is using
+        github_pullrequest_labels: 'python'


### PR DESCRIPTION
## Description
Here are couple of screenshots how PRs created by dependabot look like. I would want to reuse the same labels for the python/node/poetry updates as well since these belong in the same category (in my mind at least)

<img width="474" alt="Screenshot 2023-08-21 at 18 16 47" src="https://github.com/swappiehq/github-actions/assets/5691777/29c79915-703b-41a1-94dc-5e0689cda764">

<img width="316" alt="Screenshot 2023-08-21 at 18 15 41" src="https://github.com/swappiehq/github-actions/assets/5691777/b88748e8-2454-4c38-98bf-629d383b0032">


## Checklist
- [ ] After merging this I have tested this by manually triggering the action in one of the internal projects