### PR TITLE
Skip updating the Dockerfile for Poetry

### DIFF
--- a/update-asdf-and-dockerfile/action.yml
+++ b/update-asdf-and-dockerfile/action.yml
@@ -87,6 +87,8 @@ runs:
       run: |
         sed -i "s/^${{ inputs.plugin }} ${{ env.CURRENT_VERSION }}/${{ inputs.plugin }} ${{ env.LATEST_VERSION }}/" .tool-versions
     - name: Update latest version to Dockerfile
+    # Poetry is not inhereted directly from a Dockerfile but installed as separate step
+      if: ${{ inputs.plugin != 'poetry' }}
       shell: bash
       run: |
         test -n "${{ inputs.docker_image }}" && test -f Dockerfile && sed -i "s/^FROM ${{ inputs.docker_image }}:${{ env.CURRENT_VERSION }}/FROM ${{ inputs.docker_image }}:${{ env.LATEST_VERSION }}/" Dockerfile


### PR DESCRIPTION
## Description
The action tries to currently update the FROM clause even for poetry which is not desired since we don't inherit Poetry from other Docker image.

<img width="744" alt="image" src="https://github.com/swappiehq/github-actions/assets/5691777/e8cd6e6e-c46c-4dc9-9476-f56c8209b334">


## Checklist
- [ ] After merging this I have tested this by manually triggering the action in one of the internal projects
