### PR TITLE
Install poetry with asdf before using it

### DIFF
--- a/update-asdf-and-dockerfile/action.yml
+++ b/update-asdf-and-dockerfile/action.yml
@@ -125,8 +125,8 @@ runs:
       shell: bash
       run: |
         test -f pyproject.toml && \
+        asdf install poetry  && \
         poetry version ${{ env.LATEST_VERSION }} && \
-        asdf install poetry && \
         poetry lock --no-update
 
     # This is using the version 4.2.3


### PR DESCRIPTION
## Description
The current order of using poetry and installing poetry was wrong and the poetry needs to be installed as the first step before updating the poetry version to pyproject.toml

<img width="786" alt="image" src="https://github.com/swappiehq/github-actions/assets/5691777/1fe03104-cc3a-4ca4-9c0c-d2f359285cfd">

## Checklist
- [ ] After merging this I have tested this by manually triggering the action in one of the internal projects