### PR TITLE
Use correct SEMVER convention for major update 

### DIFF
--- a/update-asdf-and-dockerfile/action.yml
+++ b/update-asdf-and-dockerfile/action.yml
@@ -45,7 +45,7 @@ runs:
       shell: bash
       run: echo "CURRENT_VERSION=$(grep "^${{ inputs.plugin }}" .tool-versions | cut -d' ' -f2)" >> $GITHUB_ENV
     - name: Get latest version from asdf
-      if: ${{ inputs.version == 'latest' }}
+      if: ${{ inputs.version == 'major' }}
       shell: bash
       run: |
         LATEST_VERSION=$(asdf latest "${{ inputs.plugin }}")

--- a/update-nodejs/action.yml
+++ b/update-nodejs/action.yml
@@ -30,4 +30,4 @@ runs:
         # Github actions doesn't support array items so we just concatenate these
         add_extra_files_to_pr: '*package.json, *package-lock.json'
         # Use similiar PR labels as Dependabot is using
-        github_pullrequest_labels: 'javascript'
+        github_pullrequest_extra_labels: 'javascript'

--- a/update-nodejs/action.yml
+++ b/update-nodejs/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: true
     description: Selects the level of updates available for this action
     options:
-      - latest
+      - major
       - lts
       - minor # Semver minor updates from MAJOR.MINOR.PATCH
       - patch # Semver patch updates from MAJOR.MINOR.PATCH

--- a/update-poetry/action.yml
+++ b/update-poetry/action.yml
@@ -21,4 +21,4 @@ runs:
         version: '${{ inputs.version }}'
         release_notes: "https://github.com/python-poetry/poetry/releases/tag/$LATEST_VERSION"
         # Use similiar PR labels as Dependabot is using
-        github_pullrequest_label: 'python,poetry'
+        github_pullrequest_extra_labels: 'python,poetry'

--- a/update-poetry/action.yml
+++ b/update-poetry/action.yml
@@ -20,6 +20,7 @@ runs:
         plugin: poetry
         version: '${{ inputs.version }}'
         release_notes: "https://github.com/python-poetry/poetry/releases/tag/$LATEST_VERSION"
+        # Github actions doesn't support array items so we just concatenate these
+        add_extra_files_to_pr: '*pyproject.toml, *poetry.lock'
         # Use similiar PR labels as Dependabot is using
         github_pullrequest_extra_labels: 'python,poetry'
-        add_extra_files_to_pr: '*poetry.lock'

--- a/update-poetry/action.yml
+++ b/update-poetry/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: true
     description: Selects the level of updates available for this action
     options:
-      - latest
+      - major
       - minor # Semver minor updates from MAJOR.MINOR.PATCH
       - patch # Semver patch updates from MAJOR.MINOR.PATCH
 runs:

--- a/update-poetry/action.yml
+++ b/update-poetry/action.yml
@@ -22,3 +22,4 @@ runs:
         release_notes: "https://github.com/python-poetry/poetry/releases/tag/$LATEST_VERSION"
         # Use similiar PR labels as Dependabot is using
         github_pullrequest_extra_labels: 'python,poetry'
+        add_extra_files_to_pr: '*poetry.lock'

--- a/update-python/action.yml
+++ b/update-python/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: true
     description: Selects the level of updates available for this action
     options:
-      - latest
+      - major
       - minor # Semver minor updates from MAJOR.MINOR.PATCH
       - patch # Semver patch updates from MAJOR.MINOR.PATCH
 runs:

--- a/update-python/action.yml
+++ b/update-python/action.yml
@@ -25,4 +25,4 @@ runs:
         # Github actions doesn't support array items so we just concatenate these
         add_extra_files_to_pr: '*pyproject.toml, *poetry.lock'
         # Use similiar PR labels as Dependabot is using
-        github_pullrequest_labels: 'python'
+        github_pullrequest_extra_labels: 'python'


### PR DESCRIPTION
## Description
<!--
- THIS REPO IS PUBLIC AND OPEN FOR ALL INTERNET
- This was done so that we don't need to manage authentication for this repo
- And because this repo does not make our beer taste better and it can be public
- So don't share internal links into this repo
-->

This PR address two issues:

1.  When we try to update `poetry` (or any other plugin with latest version) we do not fetch the latest version eg:
<img width="714" alt="image" src="https://github.com/swappiehq/github-actions/assets/9247857/8b5295bb-c091-41bc-b9f1-84e3fbcf27f1">

This is due, according to the debug file, a comparaison being made here:

<img width="544" alt="image" src="https://github.com/swappiehq/github-actions/assets/9247857/a92366c9-9377-4deb-8583-cebb276e55e1">


In our code we compare to `latest` and it is true but then there is an extra check that look if we specified `major` (not sure where this check comes from, certainly from an extra check that llok if we correctly specified either major, minor or patch but we have the same for "minor" and "patch" [eg](https://github.com/swappiehq/laakso/actions/runs/5935374728/job/16100597863#step:2:692)). Now we will always use `major`  

Full debug logs [here](https://github.com/swappiehq/laakso/actions/runs/5935374728/job/16100597863#step:2)

**Edit 1**: the problem might come from re-running a previous version of the job instead of a fully new one. But in any case this makes things more readable ad logical according to the version by MAJOR.MINOR.PATCH of the [Semamtic Versioning](https://semver.org/) of software engineering

**Edit 2**: The problem did come from not running a new job and we got a proper update runned after that: https://github.com/swappiehq/laakso/actions/runs/5938880672 But comment from above following semver convention is still valid IMO and this PR still address the second issues

2. The other thing is addressing a warning for adding pull request labels:
<img width="1275" alt="image" src="https://github.com/swappiehq/github-actions/assets/9247857/aa267474-8620-4173-93d2-9821ec52a2d0">

3. Also added .lock file to the PR commit so that we would push the file when running the action, which is not the case in the latest run:

<img width="1573" alt="image" src="https://github.com/swappiehq/github-actions/assets/9247857/27685c45-0d38-4b20-97e1-26a8f0cc2abf">



## Checklist
- [ ] After merging this I have tested this by manually triggering the action in one of the internal projects