### PR TITLE
Update python env when updating poetry

### DIFF
--- a/update-asdf-and-dockerfile/action.yml
+++ b/update-asdf-and-dockerfile/action.yml
@@ -127,7 +127,16 @@ runs:
         test -f pyproject.toml && \
         asdf install poetry  && \
         poetry version ${{ env.LATEST_VERSION }} && \
-        poetry lock --no-update
+      # Exit the virtualenv so that poetry can install properly
+        deactivate && \
+      # Force poetry to use latest python from asdf always
+        poetry env use $(which python) && \
+      # Update the lock file without installation
+        poetry lock --no-update && \
+      # Remove all virtualenvs which are not activated so that other tools don't use them
+        poetry env list | grep -v Activated | xargs -L 1 poetry env remove && \
+      # Install the new version
+        poetry install
 
     # This is using the version 4.2.3
     # Reference the repository with SHA for security


### PR DESCRIPTION
## Description
<!--
- THIS REPO IS PUBLIC AND OPEN FOR ALL INTERNET
- This was done so that we don't need to manage authentication for this repo
- And because this repo does not make our beer taste better and it can be public
- So don't share internal links into this repo
-->

<img width="776" alt="image" src="https://github.com/swappiehq/github-actions/assets/9247857/e4b8aaa6-bbd2-4a1b-ac40-c0e3cb784d52">

It seems that when running `poetry lock` in the [latest](https://github.com/swappiehq/laakso/actions/runs/5938880672/job/16104203938#step:2:594) poetry update from GH actions we are not using the latest `python` available

This add the instructions like in https://github.com/swappiehq/hemuli#someone-updated-python-and-now-my-environment-is-broken


## Checklist
- [ ] After merging this I have tested this by manually triggering the action in one of the internal projects