### PR TITLE
Implement fixed python version in .toml

### DIFF
--- a/update-asdf-and-dockerfile/action.yml
+++ b/update-asdf-and-dockerfile/action.yml
@@ -116,7 +116,7 @@ runs:
       shell: bash
       run: |
         test -f pyproject.toml && \
-        sed -i "s/^python =.*/python = \"^${{ env.LATEST_VERSION }}\"/" pyproject.toml && \
+        sed -i "s/^python =.*/python = \"${{ env.LATEST_VERSION }}\"/" pyproject.toml && \
         asdf install python && \
         asdf install poetry && \
         poetry lock --no-update


### PR DESCRIPTION
## Description
<!--
- THIS REPO IS PUBLIC AND OPEN FOR ALL INTERNET
- This was done so that we don't need to manage authentication for this repo
- And because this repo does not make our beer taste better and it can be public
- So don't share internal links into this repo
-->

Address this [issue](https://github.com/swappiehq/laakso/pull/4729/files#r1315507995) to implement a fixed version inisde the .toml file for python update. 


## Checklist
- [ ] After merging this I have tested this by manually triggering the action in one of the internal projects