### PR TITLE
Fix python upgrade action to update image version in Dockerfile

### DIFF
--- a/update-asdf-and-dockerfile/action.yml
+++ b/update-asdf-and-dockerfile/action.yml
@@ -95,7 +95,7 @@ runs:
       if: ${{ inputs.plugin != 'poetry' }}
       shell: bash
       run: |
-        test -n "${{ inputs.docker_image }}" && test -f ${{inputs.docker_file_name}} && sed -i "s/^FROM ${{inputs.docker_file_name}}:${{ env.CURRENT_VERSION }}/FROM ${{ inputs.docker_image }}:${{ env.LATEST_VERSION }}/" ${{inputs.docker_file_name}}
+        test -n "${{ inputs.docker_image }}" && test -f ${{inputs.docker_file_name}} && sed -i "s/^FROM ${{inputs.docker_image}}:${{ env.CURRENT_VERSION }}/FROM ${{ inputs.docker_image }}:${{ env.LATEST_VERSION }}/" ${{inputs.docker_file_name}}
     # This fetches the bundled NPM version from nodejs.org so that we don't need to install nodejs+npm packages here
     - name: Update latest node/npm versions to package.json engines if it exists
       if: ${{ inputs.plugin == 'nodejs' && env.CURRENT_VERSION != env.LATEST_VERSION }}


### PR DESCRIPTION
## Description
<!--
- THIS REPO IS PUBLIC AND OPEN FOR ALL INTERNET
- This was done so that we don't need to manage authentication for this repo
- And because this repo does not make our beer taste better and it can be public
- So don't share internal links into this repo
-->

Noticed that the python upgrade action was failing to update the image version in dockerfile, this should fix it.


## Checklist
- [x] After merging this I have tested this by manually triggering the action in one of the internal projects