### PR TITLE
Bump used checkout action to v4, because v3 uses deprecated nodejs

### DIFF
--- a/update-asdf-and-dockerfile/action.yml
+++ b/update-asdf-and-dockerfile/action.yml
@@ -40,7 +40,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     # Refer to external action with git commit SHA for security.
     # Source: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
     - name: ASDF Setup plugins


### PR DESCRIPTION
The `update-asdf-and-dockerfile` action is failing currently - https://github.com/swappiehq/hemuli/actions/runs/10088730501/job/27894955257