### PR TITLE
Fix asdf update action failing

### DIFF
--- a/update-asdf-and-dockerfile/action.yml
+++ b/update-asdf-and-dockerfile/action.yml
@@ -133,11 +133,11 @@ runs:
         poetry version ${{ env.LATEST_VERSION }} && \
         poetry lock --no-update
 
-    # This is using the version 4.2.3
+    # This is using the version 6.1.0 https://github.com/peter-evans/create-pull-request/issues/2790
     # Reference the repository with SHA for security
     # Source: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
     # Here we use a wild card for the package.json files to avoid "pathspec 'xxx' did not match any files" errors as package.json files may not exist or be in subdirectories
-    - uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04
+    - uses: peter-evans/create-pull-request@370712159463f5e3e780068cb9bed6d28c27b94e
       with:
         add-paths: .tool-versions, ${{inputs.docker_file_name}}${{inputs.add_extra_files_to_pr != '' && format(', {0}', inputs.add_extra_files_to_pr) || '' }}
         commit-message: 'Update ${{ inputs.plugin }} from ${{ env.CURRENT_VERSION }} to ${{ env.LATEST_VERSION }}'

--- a/update-python/action.yml
+++ b/update-python/action.yml
@@ -19,7 +19,7 @@ runs:
     # TODO: It would be better to reference this locally but if I do it refers a local file
     # Not in the context of this repo but the repository that is using this action
     # Because of this we need to use the full path to this :(
-    - uses: swappiehq/github-actions/update-asdf-and-dockerfile@main
+    - uses: swappiehq/github-actions/update-asdf-and-dockerfile@try-to-fix-python-upgrade-action
       with:
         plugin: python
         docker_image: python

--- a/update-python/action.yml
+++ b/update-python/action.yml
@@ -19,7 +19,7 @@ runs:
     # TODO: It would be better to reference this locally but if I do it refers a local file
     # Not in the context of this repo but the repository that is using this action
     # Because of this we need to use the full path to this :(
-    - uses: swappiehq/github-actions/update-asdf-and-dockerfile@try-to-fix-python-upgrade-action
+    - uses: swappiehq/github-actions/update-asdf-and-dockerfile@main
       with:
         plugin: python
         docker_image: python


### PR DESCRIPTION
## Description
<!--
- THIS REPO IS PUBLIC AND OPEN FOR ALL INTERNET
- This was done so that we don't need to manage authentication for this repo
- And because this repo does not make our beer taste better and it can be public
- So don't share internal links into this repo
-->

Should fix random 
> Cannot read properties of undefined (reading 'number')

errors in update asdf actions, tested with internal service to work

Source for the idea:
https://github.com/peter-evans/create-pull-request/issues/2790


## Checklist
- [] After merging this I have tested this by manually triggering the action in one of the internal projects